### PR TITLE
Delete create guild

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -72,17 +72,7 @@ class Client extends BaseClient {
     return this.rest._tracer;
   }
 
-   async createGuild(name, region, icon) {
-    await this.rest.request(`${ENDPOINTS.MAIN}/guilds`, "POST", {
-    'Content-Type': 'application/json',
-    'authorization': `Bot ${this.token}`
-    }, {
-      'name': name,
-      'region': region,
-      'icon': icon
-    });
-    return this.rest._tracer;
-  }
+
 
  destroy() {
   super.destroy();


### PR DESCRIPTION
This is useless, discord will not allow a bot to create a guild. Only users are allowed to create a guild. When attempting to do this you will receive a 403.